### PR TITLE
Removing Numeracy (acquired and EOL'd Sep 2019)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ ToC split by SaaS and OSS (Open Source Software):
     - [DataRow](https://datarow.com) for AWS Redshift
     - [DbVisualizer](https://www.dbvis.com)
     - [JackDB](https://www.jackdb.com/)
-    - [Numeracy](https://numeracy.co/)
     - [POPSQL](https://popsql.io/)
     - [Postico](https://eggerapps.at/postico/)
     - [RazorSQL](https://razorsql.com/index.html)


### PR DESCRIPTION
Numeracy was acquired by Box and is being [shutdown](http://help.numeracy.io/en/articles/2803112-numeracy-shutdown-faq). 

According to the FAQ:

> Numeracy will continue running as-is for 6 months, and on September 30th, 2019 it will be shut down.

> New teams will not be able to sign up for Numeracy, but new users can be added to existing teams.